### PR TITLE
Update neutral offer template pricing

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -42,14 +42,24 @@ export default function HelpCareRechner() {
   const [twoPersons, setTwoPersons] = useState(false);
   const [manualDiscount, setManualDiscount] = useState(0);
   const [neutral, setNeutral] = useState(false);
+  const [requirementsCost, setRequirementsCost] = useState(0);
 
   const result = useMemo(() => {
-    let basis = CONFIG.fixpreis;
-    basis += CONFIG.pflegestufe1[pflegestufe1] || 0;
-    basis += twoPersons ? (CONFIG.pflegestufe2[pflegestufe2] || 0) : 0;
-    if (nacht) basis += CONFIG.zuschlaege.nachteinsaetze;
-    if (fuehrerschein) basis += CONFIG.zuschlaege.fuehrerschein;
-    basis += CONFIG.zuschlaege.deutsch[deutsch] || 0;
+    const baseFix = CONFIG.fixpreis;
+    const reqCost = Number(requirementsCost) || 0;
+    let basis = baseFix;
+    if (neutral) {
+      // Neutralangebot: Nur Grundpreis + manuell eingetragene Anforderungen
+      basis += reqCost;
+    } else {
+      // Standardangebot: Bisherige Kalkulation + Anforderungen
+      basis += CONFIG.pflegestufe1[pflegestufe1] || 0;
+      basis += twoPersons ? (CONFIG.pflegestufe2[pflegestufe2] || 0) : 0;
+      if (nacht) basis += CONFIG.zuschlaege.nachteinsaetze;
+      if (fuehrerschein) basis += CONFIG.zuschlaege.fuehrerschein;
+      basis += CONFIG.zuschlaege.deutsch[deutsch] || 0;
+      basis += reqCost;
+    }
     basis = Math.max(basis - (Number(manualDiscount) || 0), 0);
 
     let foerd = 0;
@@ -60,7 +70,7 @@ export default function HelpCareRechner() {
     if (foerderungen.verhinderung) foerd += CONFIG.foerderung.verhinderung * personsSelected;
 
     return { netto: basis, mitFoerderung: Math.max(basis - foerd, 0), foerd, pflegegeldSum, personsSelected };
-  }, [pflegestufe1, pflegestufe2, nacht, fuehrerschein, deutsch, foerderungen, twoPersons, manualDiscount]);
+  }, [pflegestufe1, pflegestufe2, nacht, fuehrerschein, deutsch, foerderungen, twoPersons, manualDiscount, requirementsCost, neutral]);
 
   function toggleFoerd(key) { setFoerderungen((prev) => ({ ...prev, [key]: !prev[key] })); }
 
@@ -182,11 +192,13 @@ export default function HelpCareRechner() {
       firstName: firstName || "–",
       lastName: lastName || "–",
       personsSelected: personsSelected,
+      basePrice: formatEUR(CONFIG.fixpreis),
+      requirementsPrice: formatEUR(Number(requirementsCost) || 0),
       globalPrice: formatEUR(result.netto),
       pflegegeldRabat: neutral ? "" : ("- " + formatEUR(pflegegeldAmount)),
       verhinderungspflege: neutral ? "" : ("- " + formatEUR(verhinderungAmount)),
       steuererleichterung: neutral ? "" : ("- " + formatEUR(steuerAmount)),
-      preisMitFoerderung: neutral ? formatEUR(result.netto) : formatEUR(result.mitFoerderung),
+      preisMitFoerderung: formatEUR(result.mitFoerderung),
       neutralDeductionsHidden: neutral ? "display:none;" : "",
     });
 
@@ -332,6 +344,9 @@ export default function HelpCareRechner() {
               <option key={key} value={key}>{key} (+{CONFIG.zuschlaege.deutsch[key]}€)</option>
             ))}
           </select>
+
+          <label className="section-title" style={{fontWeight:600}}>Anforderungen (€/Monat)</label>
+          <input type="number" className="input" style={{marginBottom:'12px'}} value={requirementsCost} onChange={(e) => setRequirementsCost(Number(e.target.value || 0))} />
 
           <label className="section-title" style={{fontWeight:600}}>Manueller Rabatt (€/Monat)</label>
           <input type="number" className="input" style={{marginBottom:'12px'}} value={manualDiscount} onChange={(e) => setManualDiscount(Number(e.target.value || 0))} />

--- a/angebotstemplate.html
+++ b/angebotstemplate.html
@@ -230,11 +230,22 @@
   <!-- SVG Hintergrund für diesen Bereich -->
 
   <div style="padding:20px; border-radius:8px; margin-bottom:25px; position: relative;">
-    <h2 style="color:#f78060; font-size:22px; margin:0 0 10px 0;">Monatlichen Betreuungskosten: <span>{globalPrice}</span></h2>
+    <h2 style="color:#f78060; font-size:22px; margin:0 0 10px 0;">Monatliche Betreuungskosten</h2>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin:10px 0;">
+      <tr>
+        <td style="padding:8px 0;">Grundpreis</td>
+        <td style="padding:8px 0; text-align:right; font-weight:bold;">{basePrice}</td>
+      </tr>
+      <tr>
+        <td style="padding:8px 0;">zzgl. Anforderungen</td>
+        <td style="padding:8px 0; text-align:right; font-weight:bold;">{requirementsPrice}</td>
+      </tr>
+    </table>
+    <div style="font-size:14px; color:#666; margin-bottom:8px;">Summe: <strong>{globalPrice}</strong></div>
     <p style="margin:0 0 15px 0; display: none;">für die von Ihnen gewählten Optionen aus dem Fragebogen</p>
     <div style="font-size:24px; font-weight:bold; margin:10px 0;"></div>
     
-    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin:20px 0; {neutralDeductionsHidden}">
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin:20px 0;">
       <tr>
         <td style="padding:10px 0; border-bottom:1px solid #ddd;">Pflegegeld für Pflegegrad</td>
         <td style="padding:10px 0; border-bottom:1px solid #ddd; text-align:right;">{pflegegeldRabat}</td>
@@ -250,7 +261,7 @@
     </table>
     
     <div style="background-color:rgba(245, 241, 235, 0.8); padding:15px; border:2px solid #f78060; border-radius:8px; text-align:center; margin-top:20px;">
-      <strong>Möglicher Eigenanteil pro Monat*</strong><br>
+      <strong>Potentieller persönlicher Eigenanteil pro Monat*</strong><br>
       <span style="font-size:24px; font-weight:bold; color:#f78060;">{preisMitFoerderung}</span>
     </div>
   </div>
@@ -259,8 +270,7 @@
             <h3 style="color:#333; font-size:18px; margin:25px 0 15px 0;">Wiederkehrende Reisekosten bei Personalwechsel</h3>
             <p style="margin:0 0 25px 0; line-height:1.6;">Je nach Entfernung und Fahrverbindung fallen für die An- und Abreise ihrer Betreuungskräfte Reisekosten an. Über die Höhe der jeweils zu tragenden Reisekosten informieren wir Sie nach erfolgter Reisebuchung.</p>
             
-            <h3 style="color:#333; font-size:18px; margin:25px 0 15px 0;">Einmalige Vermittlungsgebühr</h3>
-            <p style="margin:0 0 25px 0; line-height:1.6;">Nach erfolgter Anreise der ersten Betreuungskraft, stellt HelpCare eine Bearbeitungsgebühr von <strong>359,00 €</strong> in Rechnung.</p>
+            
             
             <p style="margin:0 0 25px 0; line-height:1.6;">Es gelten unsere Allgemeinen Geschäftsbedingungen. Diese finden Sie auf unserer Website:
             <a href="https://www.helpcare.de/agb" target="_blank" style="color:#f78060; text-decoration:underline;">https://www.helpcare.de/agb</a></p>


### PR DESCRIPTION
Adjust the neutral offer template to display a fixed base price of €2,299, include a manually entered "requirements" cost, and remove the "one-time placement fee" section.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ff1ac32-7a07-48d7-87dd-857fc317fb45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ff1ac32-7a07-48d7-87dd-857fc317fb45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

